### PR TITLE
Destroy all errors

### DIFF
--- a/bin/boot_proxy.js
+++ b/bin/boot_proxy.js
@@ -162,7 +162,7 @@ if (USE_BOOT_PROXY) {
     if(isFunction(res.destroy)) {
       res.destroy();
     } else {
-      console.error("proxy ::: res.destroy is not a function")
+      console.error("proxy ::: res.destroy is not a function");
     }
   });
 

--- a/bin/boot_proxy.js
+++ b/bin/boot_proxy.js
@@ -154,20 +154,12 @@ if (USE_BOOT_PROXY) {
         'Content-Type': 'text/plain'
       });
     } else {
-      console.error("proxy ::: res.writeHead is not a function")
-    }
-    // from https://github.com/karma-runner/karma/blob/ae05ea496b8fff1a316387f0b5919de673c5e274/lib/middleware/proxy.js#L60
-    if (err.code === 'ECONNRESET' && req.socket.destroyed) {
-      res.destroy();
-      return;
+      console.error("proxy ::: res.writeHead is not a function");
     }
 
     console.error(err);
-    if(isFunction(res.end)) {
-      res.end('There was an error');
-    } else {
-      console.error("proxy ::: res.end is not a function")
-    }
+    console.error("proxy ::: error detected, closing response");
+    res.destroy();
   });
 
   proxyServer.listen(PORT);

--- a/bin/boot_proxy.js
+++ b/bin/boot_proxy.js
@@ -156,10 +156,14 @@ if (USE_BOOT_PROXY) {
     } else {
       console.error("proxy ::: res.writeHead is not a function");
     }
-
+    
     console.error(err);
     console.error("proxy ::: error detected, closing response");
-    res.destroy();
+    if(isFunction(res.destroy)) {
+      res.destroy();
+    } else {
+      console.error("proxy ::: res.destroy is not a function")
+    }
   });
 
   proxyServer.listen(PORT);


### PR DESCRIPTION
res.end doesn't appear to be working, I haven't seen the log message from that once, i think something in meteor is keeping responses open, turning into timeout errors and lagging the system. We want to try to destroy all errors to make sure they are closed until we figure out how keepAlive is being kept on.