### PR TITLE
refuse connections to booting server

### DIFF
--- a/bin/boot_proxy.js
+++ b/bin/boot_proxy.js
@@ -128,7 +128,7 @@ if (USE_BOOT_PROXY) {
       if (bootingProxy) {
         bootingProxy.web(req, res);
       } else {
-        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.writeHead(504, { 'Content-Type': 'text/plain' });
         res.end('Waiting for app to boot...');
       }
     }


### PR DESCRIPTION
https://devcenter.heroku.com/articles/http-routing#dyno-connection-behavior
The goal here is to refuse connections to users when a dyno is booting. Herokus documentation says they will route requests to another dyno if a connection is refused. We can use this to both keep people off of booting servers and disable session-affinity mode when a dyno is restarting.

We're probably going to want a case for when there is only 1 dyno so users can go to that landing page if no dynos are up.